### PR TITLE
fixes for oF 0.9.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,98 @@
+
+# custom exclusions for ofxPDSP
+
+doxygen/doxygen_sqlite3.db
+doxygen/html
+
+
+# Some general ignore patterns
+
+*/bin/*
+!*/bin/data/
+# for bin folder in root
+/bin/*
+!/bin/data/
+
+build/
+obj/
+*.o
+Debug*/
+Release*/
+*.mode*
+*.app/
+*.pyc
+.svn/
+
+# IDE-specific ignore patterns (e.g. user-specific files)
+
+#XCode
+*.pbxuser
+*.perspective
+*.perspectivev3
+*.mode1v3
+*.mode2v3
+#XCode 4
+xcuserdata
+*.xcworkspace
+
+#Code::Blocks
+*.depend
+*.layout
+*.cbTemp
+
+#Visual Studio
+*.sdf
+*.opensdf
+*.suo
+ipch/
+
+#Eclipse
+.metadata
+local.properties
+.externalToolBuilders
+
+
+#codelite
+*.session
+*.tags
+*.workspace.*
+
+# OS-specific ignore patterns
+
+#Linux
+*~
+# KDE
+.directory
+
+#OSX
+.DS_Store
+*.swp
+*~.nib
+# Thumbnails
+._*
+
+#Windows
+# Windows image file caches
+Thumbs.db
+# Folder config file
+Desktop.ini
+
+#Android
+.csettings
+
+# Packages
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Logs and databases
+*.log
+*.sql
+*.sqlite

--- a/calibration/Makefile
+++ b/calibration/Makefile
@@ -6,7 +6,7 @@ endif
 
 # make sure the the OF_ROOT location is defined
 ifndef OF_ROOT
-    OF_ROOT=../../..
+    OF_ROOT=$(realpath ../../..)
 endif
 
 # call the project makefile!

--- a/calibration/addons.make
+++ b/calibration/addons.make
@@ -2,5 +2,4 @@ ofxCv
 ofxKinect
 ofxKinectProjectorToolkit
 ofxOpenCv
-ofxSecondWindow
 ofxXmlSettings

--- a/calibration/config.make
+++ b/calibration/config.make
@@ -70,13 +70,12 @@
 #		(default) PROJECT_LDFLAGS = -Wl,-rpath=./libs
 #
 #   Note: Leave a leading space when adding list items with the += operator
-################################################################################
-
+#
 # Currently, shared libraries that are needed are copied to the 
 # $(PROJECT_ROOT)/bin/libs directory.  The following LDFLAGS tell the linker to
 # add a runtime path to search for those shared libraries, since they aren't 
 # incorporated directly into the final executable application binary.
-# TODO: should this be a default setting?
+################################################################################
 # PROJECT_LDFLAGS=-Wl,-rpath=./libs
 
 ################################################################################

--- a/calibration/src/ofApp.cpp
+++ b/calibration/src/ofApp.cpp
@@ -14,6 +14,9 @@ void ofApp::setup(){
     rgbImage.allocate(kinect.width, kinect.height);
     
     fboChessboard.allocate(PROJECTOR_RESOLUTION_X, PROJECTOR_RESOLUTION_Y, GL_RGBA);
+    
+    // reset angle, b
+    angle = 0;
 }
 
 //--------------------------------------------------------------
@@ -81,7 +84,7 @@ void ofApp::addPointPair() {
 void ofApp::update(){
     kinect.update();
     if (kinect.isFrameNew()) {
-        rgbImage.setFromPixels(kinect.getPixels(), kinect.width, kinect.height);
+        rgbImage.setFromPixels(kinect.getPixels().getData(), kinect.width, kinect.height);
         if (testing) {
             ofVec2f t = ofVec2f(min(kinect.getWidth()-1,testPoint.x), min(kinect.getHeight()-1,testPoint.y));
             ofVec3f worldPoint = kinect.getWorldCoordinateAt(t.x, t.y);
@@ -131,6 +134,7 @@ void ofApp::draw(){
         ofSetColor(0);
         ofDrawBitmapString(ofToString(pairsKinect.size())+" point pairs collected.", 340, 630);
     }
+    ofDrawBitmapString("kinect angle :" + ofToString(angle), 340, 650 );
     ofSetColor(255);
 }
 
@@ -141,22 +145,50 @@ void ofApp::drawSecondWindow(ofEventArgs &args){
 
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key){
-    if (key==' '){
+    
+    switch (key) {
+    case ' ':
         addPointPair();
-    } else if (key=='q') {
+    break;
+    case 'q':
         chessboardSize -= 20;
-    } else if (key=='w') {
+        break;
+    case 'w':
         chessboardSize += 20;
-    } else if (key=='c') {
+        break;
+    case 'c':
+
         kpt.calibrate(pairsKinect, pairsProjector);
         testing = true;
-    } else if (key=='s') {
+        break;
+    case 's':
         kpt.saveCalibration("calibration.xml");
         saved = true;
-    } else if (key=='l') {
+        break;
+    case 'l':
         kpt.loadCalibration("calibration.xml");
         testing = true;
+        break;
+        
+    case OF_KEY_UP:
+        angle++;
+        if(angle>30) angle=30;
+        kinect.setCameraTiltAngle(angle);
+        break;
+        
+    case OF_KEY_DOWN:
+        angle--;
+        if(angle<-30) angle=-30;
+        kinect.setCameraTiltAngle(angle);
+        break;
+        
+    case '0':
+        angle = 0;
+        kinect.setCameraTiltAngle(angle);
+    break;
+	
     }
+    
 }
 
 //--------------------------------------------------------------

--- a/calibration/src/ofApp.h
+++ b/calibration/src/ofApp.h
@@ -48,6 +48,9 @@ public:
     int                         chessboardY;
     bool                        testing;
     bool                        saved;
+    
+	int angle;
+
 };
 
 

--- a/example_contourMap/addons.make
+++ b/example_contourMap/addons.make
@@ -3,4 +3,3 @@ ofxGui
 ofxKinect
 ofxKinectProjectorToolkit
 ofxOpenCv
-ofxSecondWindow

--- a/example_contourMap/src/main.cpp
+++ b/example_contourMap/src/main.cpp
@@ -3,11 +3,26 @@
 
 //========================================================================
 int main( ){
-	ofSetupOpenGL(1024,768,OF_WINDOW);			// <-------- setup the GL context
+    ofGLFWWindowSettings settings;
 
-	// this kicks off the running of my app
-	// can be OF_WINDOW or OF_FULLSCREEN
-	// pass in width and height too:
-	ofRunApp(new ofApp());
+    settings.width = 1024;
+    settings.height = 768;
+    settings.setPosition(ofVec2f(100, 100));
+    settings.resizable = true;
+    shared_ptr<ofAppBaseWindow> mainWindow = ofCreateWindow(settings);
 
+    settings.width = PROJECTOR_RESOLUTION_X;
+    settings.height = PROJECTOR_RESOLUTION_Y;
+    settings.setPosition(ofVec2f(ofGetScreenWidth(), 0));
+    settings.resizable = false;
+    settings.decorated = false;
+    settings.shareContextWith = mainWindow;
+    shared_ptr<ofAppBaseWindow> secondWindow = ofCreateWindow(settings);
+    secondWindow->setVerticalSync(false);
+
+    shared_ptr<ofApp> mainApp(new ofApp);
+    ofAddListener(secondWindow->events().draw, mainApp.get(), &ofApp::drawSecondWindow);
+    
+    ofRunApp(mainWindow, mainApp);
+    ofRunMainLoop();
 }

--- a/example_contourMap/src/ofApp.cpp
+++ b/example_contourMap/src/ofApp.cpp
@@ -28,8 +28,7 @@ void ofApp::setup() {
     grayThreshFar.allocate(kinect.width, kinect.height);
     
     kpt.loadCalibration("/Users/Gene/Desktop/calibration.xml");
-    
-    projector.setup("main", ofGetScreenWidth(), 0, PROJECTOR_RESOLUTION_X, PROJECTOR_RESOLUTION_Y, true);
+
     
     // setup gui
     gui.setup("parameters");
@@ -47,7 +46,7 @@ void ofApp::update() {
     
     if(kinect.isFrameNew()) {
         // process kinect depth image
-        grayImage.setFromPixels(kinect.getDepthPixels(), kinect.width, kinect.height);
+        grayImage.setFromPixels(kinect.getDepthPixels().getData(), kinect.width, kinect.height);
         grayThreshNear = grayImage;
         grayThreshFar = grayImage;
         grayThreshNear.threshold(nearThreshold, true);
@@ -68,25 +67,29 @@ void ofApp::update() {
 }
 
 void ofApp::draw() {
+
     // GUI
     ofBackground(0);
     ofSetColor(255);
+
     ofPushMatrix();
-    kinect.draw(0, 0);
-    ofTranslate(640, 0);
-    grayImage.draw(0, 0);
-    ofTranslate(-640, 480);
-    contourFinder.draw();
-    ofTranslate(640, 0);
+        kinect.draw(0, 0);
+        ofTranslate(640, 0);
+        grayImage.draw(0, 0);
+        ofTranslate(-640, 480);
+        contourFinder.draw();
+        ofTranslate(640, 0);
     ofPopMatrix();
     
     gui.draw();
     
+}
+
+void ofApp::drawSecondWindow(ofEventArgs &args){
+  
     // MAIN WINDOW
-    projector.begin();
-    
     ofBackground(0);
-    
+
     RectTracker& tracker = contourFinder.getTracker();
     
     for(int i = 0; i < contourFinder.size(); i++) {
@@ -103,12 +106,11 @@ void ofApp::draw() {
         for (int j=0; j<points.size(); j++) {
             ofVec3f worldPoint = kinect.getWorldCoordinateAt(points[j].x, points[j].y);
             ofVec2f projectedPoint = kpt.getProjectedPoint(worldPoint);
-            ofVertex(projector.getWidth() * projectedPoint.x, projector.getHeight() * projectedPoint.y);
+            ofVertex( PROJECTOR_RESOLUTION_X * projectedPoint.x, PROJECTOR_RESOLUTION_Y * projectedPoint.y );
         }
         ofEndShape();
     }
     
-    projector.end();
 }
 
 void ofApp::keyPressed(int key) {

--- a/example_contourMap/src/ofApp.h
+++ b/example_contourMap/src/ofApp.h
@@ -4,7 +4,6 @@
 #include "ofxOpenCv.h"
 #include "ofxCv.h"
 #include "ofxKinect.h"
-#include "ofxSecondWindow.h"
 #include "ofxKinectProjectorToolkit.h"
 #include "ofxGui.h"
 
@@ -24,9 +23,8 @@ public:
     void setup();
     void update();
     void draw();
+    void drawSecondWindow(ofEventArgs& args);
     void keyPressed(int key);
-    
-    ofxSecondWindow             projector;
     
     ofxPanel                    gui;
     ofColor                     blobColors[12];


### PR DESCRIPTION
i had to modify a bit the examples that don't use openNI to making them up to date with oF 0.9.x 
- fixes the non-openni examples
- no need for ofxSecondWindow for example_contourMap
- adds kinect tilt to calibration with up/down keys and reset with 0 (no reset on startup)
- adds .gitignore file

tested on Debian Linux 8. 
Cheers!